### PR TITLE
更新userService中查询登录用户权限的逻辑实现，删除不再使用的接口

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   push:
     branches:
-      - webflux
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 on:
   push:
     branches:
-      - master
+      - webflux
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,17 +35,6 @@ jobs:
         with:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
-      - name: Codecov
-        uses: codecov/codecov-action@v2
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./coverage/reports/
-          env_vars: OS,JAVA
-          fail_ci_if_error: true
-          flags: unittests
-          files: ./coverage1.xml,./coverage2.xml
-          name: codecov-umbrella
-          verbose: true
       - name: Build and analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any

--- a/assets/src/main/java/io/leafage/basic/assets/controller/CategoryController.java
+++ b/assets/src/main/java/io/leafage/basic/assets/controller/CategoryController.java
@@ -13,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import javax.validation.Valid;
 
 /**
@@ -89,6 +88,24 @@ public class CategoryController {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(count);
+    }
+
+    /**
+     * 是否已存在
+     *
+     * @param alias 名称
+     * @return true-是，false-否
+     */
+    @GetMapping("/exist")
+    public ResponseEntity<Mono<Boolean>> exists(@RequestParam String alias) {
+        Mono<Boolean> existsMono;
+        try {
+            existsMono = categoryService.exists(alias);
+        } catch (Exception e) {
+            logger.error("Check category is exist an error: ", e);
+            return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
+        }
+        return ResponseEntity.ok().body(existsMono);
     }
 
     /**

--- a/assets/src/main/java/io/leafage/basic/assets/controller/PortfolioController.java
+++ b/assets/src/main/java/io/leafage/basic/assets/controller/PortfolioController.java
@@ -13,7 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import javax.validation.Valid;
 
 /**
@@ -87,6 +86,24 @@ public class PortfolioController {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(count);
+    }
+
+    /**
+     * 是否已存在
+     *
+     * @param title 标题
+     * @return true-是，false-否
+     */
+    @GetMapping("/exist")
+    public ResponseEntity<Mono<Boolean>> exists(@RequestParam String title) {
+        Mono<Boolean> existsMono;
+        try {
+            existsMono = portfolioService.exists(title);
+        } catch (Exception e) {
+            logger.error("Check portfolio is exist an error: ", e);
+            return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
+        }
+        return ResponseEntity.ok().body(existsMono);
     }
 
     /**

--- a/assets/src/main/java/io/leafage/basic/assets/controller/PostsController.java
+++ b/assets/src/main/java/io/leafage/basic/assets/controller/PostsController.java
@@ -87,10 +87,10 @@ public class PostsController {
      * @return 查询到数据，异常时返回204
      */
     @GetMapping("/{code}/details")
-    public ResponseEntity<Mono<PostsContentVO>> fetchDetails(@PathVariable String code) {
+    public ResponseEntity<Mono<PostsContentVO>> details(@PathVariable String code) {
         Mono<PostsContentVO> voMono;
         try {
-            voMono = postsService.fetchDetails(code);
+            voMono = postsService.details(code);
         } catch (Exception e) {
             logger.error("Fetch posts details occurred an error: ", e);
             return ResponseEntity.noContent().build();
@@ -123,10 +123,10 @@ public class PostsController {
      * @return 查询到数据，异常时返回204
      */
     @GetMapping("/{code}/content")
-    public ResponseEntity<Mono<ContentVO>> fetchContent(@PathVariable String code) {
+    public ResponseEntity<Mono<ContentVO>> content(@PathVariable String code) {
         Mono<ContentVO> voMono;
         try {
-            voMono = postsService.fetchContent(code);
+            voMono = postsService.content(code);
         } catch (Exception e) {
             logger.error("Fetch posts occurred an error: ", e);
             return ResponseEntity.noContent().build();
@@ -152,16 +152,34 @@ public class PostsController {
     }
 
     /**
+     * 是否已存在
+     *
+     * @param title 标题
+     * @return true-是，false-否
+     */
+    @GetMapping("/exist")
+    public ResponseEntity<Mono<Boolean>> exists(@RequestParam String title) {
+        Mono<Boolean> existsMono;
+        try {
+            existsMono = postsService.exists(title);
+        } catch (Exception e) {
+            logger.error("Check posts is exist an error: ", e);
+            return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
+        }
+        return ResponseEntity.ok().body(existsMono);
+    }
+
+    /**
      * 根据传入的代码查询下一条记录
      *
      * @param code 代码
      * @return 查询到数据，异常时返回204
      */
     @GetMapping("/{code}/next")
-    public ResponseEntity<Mono<PostsVO>> fetchNext(@PathVariable String code) {
+    public ResponseEntity<Mono<PostsVO>> next(@PathVariable String code) {
         Mono<PostsVO> voMono;
         try {
-            voMono = postsService.nextPosts(code);
+            voMono = postsService.next(code);
         } catch (Exception e) {
             logger.error("Fetch next posts occurred an error: ", e);
             return ResponseEntity.noContent().build();
@@ -176,10 +194,10 @@ public class PostsController {
      * @return 查询到数据，异常时返回204
      */
     @GetMapping("/{code}/previous")
-    public ResponseEntity<Mono<PostsVO>> fetchPrevious(@PathVariable String code) {
+    public ResponseEntity<Mono<PostsVO>> previous(@PathVariable String code) {
         Mono<PostsVO> voMono;
         try {
-            voMono = postsService.previousPosts(code);
+            voMono = postsService.previous(code);
         } catch (Exception e) {
             logger.error("Fetch previous posts occurred an error: ", e);
             return ResponseEntity.noContent().build();
@@ -194,10 +212,10 @@ public class PostsController {
      * @return 操作后的信息，否则返回417状态码
      */
     @PatchMapping("/{code}/like")
-    public ResponseEntity<Mono<Integer>> incrementLikes(@PathVariable String code) {
+    public ResponseEntity<Mono<Integer>> like(@PathVariable String code) {
         Mono<Integer> voMono;
         try {
-            voMono = postsService.incrementLikes(code);
+            voMono = postsService.like(code);
         } catch (Exception e) {
             logger.error("Increment posts like occurred an error: ", e);
             return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();

--- a/assets/src/main/java/io/leafage/basic/assets/repository/CategoryRepository.java
+++ b/assets/src/main/java/io/leafage/basic/assets/repository/CategoryRepository.java
@@ -41,4 +41,12 @@ public interface CategoryRepository extends ReactiveMongoRepository<Category, Ob
      * @return 类别信息
      */
     Mono<Category> getByCodeAndEnabledTrue(String code);
+
+    /**
+     * 是否已存在
+     *
+     * @param alias 名称
+     * @return true-是，false-否
+     */
+    Mono<Boolean> existsByAlias(String alias);
 }

--- a/assets/src/main/java/io/leafage/basic/assets/repository/PortfolioRepository.java
+++ b/assets/src/main/java/io/leafage/basic/assets/repository/PortfolioRepository.java
@@ -34,4 +34,12 @@ public interface PortfolioRepository extends ReactiveMongoRepository<Portfolio, 
      * @return 作品信息
      */
     Mono<Portfolio> getByCodeAndEnabledTrue(String code);
+
+    /**
+     * 是否已存在
+     *
+     * @param title 名称
+     * @return true-是，false-否
+     */
+    Mono<Boolean> existsByTitle(String title);
 }

--- a/assets/src/main/java/io/leafage/basic/assets/repository/PostsRepository.java
+++ b/assets/src/main/java/io/leafage/basic/assets/repository/PostsRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import javax.validation.constraints.NotNull;
 
 /**
@@ -86,4 +85,12 @@ public interface PostsRepository extends ReactiveMongoRepository<Posts, ObjectId
      * @return 匹配结果
      */
     Flux<Posts> findByTitleIgnoreCaseLikeAndEnabledTrue(String title);
+
+    /**
+     * 是否已存在
+     *
+     * @param title 名称
+     * @return true-是，false-否
+     */
+    Mono<Boolean> existsByTitle(String title);
 }

--- a/assets/src/main/java/io/leafage/basic/assets/service/CategoryService.java
+++ b/assets/src/main/java/io/leafage/basic/assets/service/CategoryService.java
@@ -5,6 +5,7 @@ package io.leafage.basic.assets.service;
 
 import io.leafage.basic.assets.dto.CategoryDTO;
 import io.leafage.basic.assets.vo.CategoryVO;
+import reactor.core.publisher.Mono;
 import top.leafage.common.reactive.ReactiveBasicService;
 
 /**
@@ -13,4 +14,12 @@ import top.leafage.common.reactive.ReactiveBasicService;
  * @author liwenqiang 2020/2/13 20:16
  **/
 public interface CategoryService extends ReactiveBasicService<CategoryDTO, CategoryVO> {
+
+    /**
+     * 是否已存在
+     *
+     * @param alias 名称
+     * @return true-是，false-否
+     */
+    Mono<Boolean> exists(String alias);
 }

--- a/assets/src/main/java/io/leafage/basic/assets/service/PortfolioService.java
+++ b/assets/src/main/java/io/leafage/basic/assets/service/PortfolioService.java
@@ -5,7 +5,7 @@ package io.leafage.basic.assets.service;
 
 import io.leafage.basic.assets.dto.PortfolioDTO;
 import io.leafage.basic.assets.vo.PortfolioVO;
-import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import top.leafage.common.reactive.ReactiveBasicService;
 
 /**
@@ -16,13 +16,10 @@ import top.leafage.common.reactive.ReactiveBasicService;
 public interface PortfolioService extends ReactiveBasicService<PortfolioDTO, PortfolioVO> {
 
     /**
-     * 按照分页和分类进行查询并排序
+     * 是否已存在
      *
-     * @param page  分页
-     * @param size  大小
-     * @param order 排序
-     * @return 结果集
+     * @param title 名称
+     * @return true-是，false-否
      */
-    Flux<PortfolioVO> retrieve(int page, int size, String order);
-
+    Mono<Boolean> exists(String title);
 }

--- a/assets/src/main/java/io/leafage/basic/assets/service/PostsService.java
+++ b/assets/src/main/java/io/leafage/basic/assets/service/PostsService.java
@@ -35,7 +35,7 @@ public interface PostsService extends ReactiveBasicService<PostsDTO, PostsVO> {
      * @param code 代码
      * @return 详细信息
      */
-    Mono<PostsContentVO> fetchDetails(String code);
+    Mono<PostsContentVO> details(String code);
 
     /**
      * 根据代码查询内容
@@ -43,7 +43,7 @@ public interface PostsService extends ReactiveBasicService<PostsDTO, PostsVO> {
      * @param code 代码
      * @return 详细信息
      */
-    Mono<ContentVO> fetchContent(String code);
+    Mono<ContentVO> content(String code);
 
     /**
      * 下一条记录
@@ -51,7 +51,7 @@ public interface PostsService extends ReactiveBasicService<PostsDTO, PostsVO> {
      * @param code 代码
      * @return 帖子信息
      */
-    Mono<PostsVO> nextPosts(String code);
+    Mono<PostsVO> next(String code);
 
     /**
      * 上一条记录
@@ -59,7 +59,7 @@ public interface PostsService extends ReactiveBasicService<PostsDTO, PostsVO> {
      * @param code 代码
      * @return 帖子信息
      */
-    Mono<PostsVO> previousPosts(String code);
+    Mono<PostsVO> previous(String code);
 
     /**
      * 自增likes
@@ -67,7 +67,7 @@ public interface PostsService extends ReactiveBasicService<PostsDTO, PostsVO> {
      * @param code 代码
      * @return 最新 likes
      */
-    Mono<Integer> incrementLikes(String code);
+    Mono<Integer> like(String code);
 
     /**
      * 全文搜索
@@ -76,4 +76,12 @@ public interface PostsService extends ReactiveBasicService<PostsDTO, PostsVO> {
      * @return 匹配结果
      */
     Flux<PostsVO> search(String keyword);
+
+    /**
+     * 是否已存在
+     *
+     * @param title 名称
+     * @return true-是，false-否
+     */
+    Mono<Boolean> exists(String title);
 }

--- a/assets/src/main/java/io/leafage/basic/assets/service/impl/CategoryServiceImpl.java
+++ b/assets/src/main/java/io/leafage/basic/assets/service/impl/CategoryServiceImpl.java
@@ -16,7 +16,6 @@ import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import top.leafage.common.basic.AbstractBasicService;
-
 import javax.naming.NotContextException;
 
 /**
@@ -26,6 +25,8 @@ import javax.naming.NotContextException;
  **/
 @Service
 public class CategoryServiceImpl extends AbstractBasicService implements CategoryService {
+
+    private static final String MESSAGE = "code is blank.";
 
     private final CategoryRepository categoryRepository;
     private final PostsRepository postsRepository;
@@ -47,7 +48,7 @@ public class CategoryServiceImpl extends AbstractBasicService implements Categor
 
     @Override
     public Mono<CategoryVO> fetch(String code) {
-        Assert.hasText(code, "code is blank");
+        Assert.hasText(code, MESSAGE);
         return categoryRepository.getByCodeAndEnabledTrue(code).flatMap(this::fetchOuter);
     }
 
@@ -66,15 +67,15 @@ public class CategoryServiceImpl extends AbstractBasicService implements Categor
 
     @Override
     public Mono<CategoryVO> modify(String code, CategoryDTO categoryDTO) {
-        Assert.hasText(code, "code is blank");
+        Assert.hasText(code, MESSAGE);
         return categoryRepository.getByCodeAndEnabledTrue(code).doOnNext(category ->
-                BeanUtils.copyProperties(categoryDTO, category)).switchIfEmpty(Mono.error(NotContextException::new))
+                        BeanUtils.copyProperties(categoryDTO, category)).switchIfEmpty(Mono.error(NotContextException::new))
                 .flatMap(categoryRepository::save).flatMap(this::convertOuter);
     }
 
     @Override
     public Mono<Void> remove(String code) {
-        Assert.hasText(code, "code is blank");
+        Assert.hasText(code, MESSAGE);
         return categoryRepository.getByCodeAndEnabledTrue(code).flatMap(topic -> categoryRepository.deleteById(topic.getId()));
     }
 
@@ -111,5 +112,11 @@ public class CategoryServiceImpl extends AbstractBasicService implements Categor
             vo.setCount(count);
             return vo;
         });
+    }
+
+    @Override
+    public Mono<Boolean> exists(String alias) {
+        Assert.hasText(alias, "alias is blank.");
+        return categoryRepository.existsByAlias(alias);
     }
 }

--- a/assets/src/main/java/io/leafage/basic/assets/service/impl/PortfolioServiceImpl.java
+++ b/assets/src/main/java/io/leafage/basic/assets/service/impl/PortfolioServiceImpl.java
@@ -17,7 +17,6 @@ import org.springframework.util.StringUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import top.leafage.common.basic.AbstractBasicService;
-
 import javax.naming.NotContextException;
 
 /**
@@ -27,6 +26,8 @@ import javax.naming.NotContextException;
  **/
 @Service
 public class PortfolioServiceImpl extends AbstractBasicService implements PortfolioService {
+
+    private static final String MESSAGE = "code is blank.";
 
     private final PortfolioRepository portfolioRepository;
 
@@ -38,6 +39,12 @@ public class PortfolioServiceImpl extends AbstractBasicService implements Portfo
     public Flux<PortfolioVO> retrieve(int page, int size, String order) {
         return portfolioRepository.findByEnabledTrue(PageRequest.of(page, size, Sort.by(Sort.Direction.DESC,
                 StringUtils.hasText(order) ? order : "modifyTime"))).map(this::convertOuter);
+    }
+
+    @Override
+    public Mono<Boolean> exists(String title) {
+        Assert.hasText(title, "title is blank.");
+        return portfolioRepository.existsByTitle(title);
     }
 
     @Override
@@ -55,7 +62,7 @@ public class PortfolioServiceImpl extends AbstractBasicService implements Portfo
 
     @Override
     public Mono<PortfolioVO> modify(String code, PortfolioDTO portfolioDTO) {
-        Assert.hasText(code, "code is blank");
+        Assert.hasText(code, MESSAGE);
         return portfolioRepository.getByCodeAndEnabledTrue(code).switchIfEmpty(Mono.error(NotContextException::new))
                 .doOnNext(portfolio -> BeanUtils.copyProperties(portfolioDTO, portfolio))
                 .flatMap(portfolioRepository::save).map(this::convertOuter);
@@ -63,13 +70,13 @@ public class PortfolioServiceImpl extends AbstractBasicService implements Portfo
 
     @Override
     public Mono<Void> remove(String code) {
-        Assert.hasText(code, "code is blank");
+        Assert.hasText(code, MESSAGE);
         return portfolioRepository.getByCodeAndEnabledTrue(code).flatMap(article -> portfolioRepository.deleteById(article.getId()));
     }
 
     @Override
     public Mono<PortfolioVO> fetch(String code) {
-        Assert.hasText(code, "code is blank");
+        Assert.hasText(code, MESSAGE);
         return portfolioRepository.getByCodeAndEnabledTrue(code).map(this::convertOuter);
     }
 

--- a/assets/src/test/java/io/leafage/basic/assets/controller/PostsControllerTest.java
+++ b/assets/src/test/java/io/leafage/basic/assets/controller/PostsControllerTest.java
@@ -19,9 +19,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import java.util.Collections;
-
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 
@@ -41,7 +39,7 @@ class PostsControllerTest {
     private WebTestClient webClient;
 
     @Test
-    public void retrieve() {
+    void retrieve() {
         PostsVO postsVO = new PostsVO();
         postsVO.setTitle("test");
         given(this.postsService.retrieve(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
@@ -51,31 +49,31 @@ class PostsControllerTest {
     }
 
     @Test
-    public void retrieve_page() {
+    void retrieve_page() {
         PostsVO postsVO = new PostsVO();
         postsVO.setTitle("test");
         given(this.postsService.retrieve(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
                 .willReturn(Flux.just(postsVO));
 
         webClient.get().uri(uriBuilder -> uriBuilder.path("/posts").queryParam("page", 0)
-                .queryParam("size", 2).build()).exchange()
+                        .queryParam("size", 2).build()).exchange()
                 .expectStatus().isOk().expectBodyList(PostsVO.class);
     }
 
     @Test
-    public void retrieve_page_category() {
+    void retrieve_page_category() {
         PostsVO postsVO = new PostsVO();
         postsVO.setTitle("test");
         given(this.postsService.retrieve(Mockito.anyInt(), Mockito.anyInt(), Mockito.anyString(), Mockito.anyString()))
                 .willReturn(Flux.just(postsVO));
 
         webClient.get().uri(uriBuilder -> uriBuilder.path("/posts").queryParam("page", 0)
-                .queryParam("size", 2).queryParam("category", "21213G0J2").build()).exchange()
+                        .queryParam("size", 2).queryParam("category", "21213G0J2").build()).exchange()
                 .expectStatus().isOk().expectBodyList(PostsVO.class);
     }
 
     @Test
-    public void fetch() {
+    void fetch() {
         PostsVO postsVO = new PostsVO();
         postsVO.setTitle("test");
         given(this.postsService.fetch(Mockito.anyString())).willReturn(Mono.just(postsVO));
@@ -85,10 +83,10 @@ class PostsControllerTest {
     }
 
     @Test
-    public void fetchDetails() {
+    void details() {
         PostsContentVO postsContentVO = new PostsContentVO();
         postsContentVO.setContent("test");
-        given(this.postsService.fetchDetails(Mockito.anyString())).willReturn(Mono.just(postsContentVO));
+        given(this.postsService.details(Mockito.anyString())).willReturn(Mono.just(postsContentVO));
 
         webClient.get().uri("/posts/{code}/details", "21213G0J2").exchange()
                 .expectStatus().isOk()
@@ -96,10 +94,10 @@ class PostsControllerTest {
     }
 
     @Test
-    public void fetchContent() {
+    void content() {
         ContentVO contentVO = new ContentVO();
         contentVO.setContent("test");
-        given(this.postsService.fetchContent(Mockito.anyString())).willReturn(Mono.just(contentVO));
+        given(this.postsService.content(Mockito.anyString())).willReturn(Mono.just(contentVO));
 
         webClient.get().uri("/posts/{code}/content", "21213G0J2").exchange()
                 .expectStatus().isOk()
@@ -107,19 +105,19 @@ class PostsControllerTest {
     }
 
     @Test
-    public void incrementLikes() {
-        given(this.postsService.incrementLikes(Mockito.anyString())).willReturn(Mono.just(2));
+    void like() {
+        given(this.postsService.like(Mockito.anyString())).willReturn(Mono.just(2));
 
         webClient.patch().uri("/posts/{code}/like", "21213G0J2").exchange()
                 .expectStatus().isOk();
-        Mockito.verify(postsService, times(1)).incrementLikes(Mockito.anyString());
+        Mockito.verify(postsService, times(1)).like(Mockito.anyString());
     }
 
     @Test
-    public void previousPosts() {
+    void previous() {
         PostsVO postsVO = new PostsVO();
         postsVO.setTitle("test");
-        given(this.postsService.previousPosts(Mockito.anyString())).willReturn(Mono.just(postsVO));
+        given(this.postsService.previous(Mockito.anyString())).willReturn(Mono.just(postsVO));
 
         webClient.get().uri("/posts/{code}/previous", "21213G0J2").exchange()
                 .expectStatus().isOk()
@@ -127,10 +125,10 @@ class PostsControllerTest {
     }
 
     @Test
-    public void nextPosts() {
+    void next() {
         PostsVO postsVO = new PostsVO();
         postsVO.setTitle("test");
-        given(this.postsService.nextPosts(Mockito.anyString())).willReturn(Mono.just(postsVO));
+        given(this.postsService.next(Mockito.anyString())).willReturn(Mono.just(postsVO));
 
         webClient.get().uri("/posts/{code}/next", "21213G0J2").exchange()
                 .expectStatus().isOk()
@@ -138,24 +136,24 @@ class PostsControllerTest {
     }
 
     @Test
-    public void search() {
+    void search() {
         PostsVO postsVO = new PostsVO();
         postsVO.setTitle("test");
         given(this.postsService.search(Mockito.anyString())).willReturn(Flux.just(postsVO));
 
         webClient.get().uri(uriBuilder ->
-                uriBuilder.path("/posts/search").queryParam("keyword", "test").build()).exchange()
+                        uriBuilder.path("/posts/search").queryParam("keyword", "test").build()).exchange()
                 .expectStatus().isOk();
     }
 
     @Test
-    public void count() {
+    void count() {
         given(this.postsService.count()).willReturn(Mono.just(2L));
         webClient.get().uri("/posts/count").exchange().expectStatus().isOk();
     }
 
     @Test
-    public void create() {
+    void create() {
         // 构造返回对象
         PostsVO postsVO = new PostsVO();
         postsVO.setTitle("test");
@@ -176,7 +174,7 @@ class PostsControllerTest {
     }
 
     @Test
-    public void modify() {
+    void modify() {
         // 构造返回对象
         PostsVO postsVO = new PostsVO();
         postsVO.setTitle("test");

--- a/assets/src/test/java/io/leafage/basic/assets/service/impl/PostsServiceImplTest.java
+++ b/assets/src/test/java/io/leafage/basic/assets/service/impl/PostsServiceImplTest.java
@@ -28,7 +28,6 @@ import org.springframework.data.mongodb.core.query.Update;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
 import static org.mockito.BDDMockito.given;
 
 /**
@@ -115,13 +114,13 @@ class PostsServiceImplTest {
 
         given(this.postsContentService.fetchByPostsId(id)).willReturn(Mono.just(Mockito.mock(PostsContent.class)));
 
-        StepVerifier.create(this.postsService.fetchDetails("21213G0J2")).expectNextCount(1).verifyComplete();
+        StepVerifier.create(this.postsService.details("21213G0J2")).expectNextCount(1).verifyComplete();
     }
 
     @Test
     void fetchDetails_empty() {
         given(this.postsRepository.getByCodeAndEnabledTrue(Mockito.anyString())).willReturn(Mono.empty());
-        StepVerifier.create(this.postsService.fetchDetails("21213G0J2")).verifyError();
+        StepVerifier.create(this.postsService.details("21213G0J2")).verifyError();
     }
 
     @Test
@@ -145,7 +144,7 @@ class PostsServiceImplTest {
 
         given(this.postsContentService.fetchByPostsId(Mockito.any(ObjectId.class))).willReturn(Mono.just(Mockito.mock(PostsContent.class)));
 
-        StepVerifier.create(postsService.fetchContent("21213G0J2")).expectNextCount(1).verifyComplete();
+        StepVerifier.create(postsService.content("21213G0J2")).expectNextCount(1).verifyComplete();
     }
 
     @Test
@@ -247,7 +246,7 @@ class PostsServiceImplTest {
 
         given(this.categoryRepository.findById(posts.getCategoryId())).willReturn(Mono.just(Mockito.mock(Category.class)));
 
-        StepVerifier.create(postsService.nextPosts("21213G0J2")).expectNextCount(1).verifyComplete();
+        StepVerifier.create(postsService.next("21213G0J2")).expectNextCount(1).verifyComplete();
     }
 
     @Test
@@ -263,7 +262,7 @@ class PostsServiceImplTest {
 
         given(this.categoryRepository.findById(posts.getCategoryId())).willReturn(Mono.just(Mockito.mock(Category.class)));
 
-        StepVerifier.create(postsService.previousPosts("21213G0J2")).expectNextCount(1).verifyComplete();
+        StepVerifier.create(postsService.previous("21213G0J2")).expectNextCount(1).verifyComplete();
     }
 
     @Test
@@ -273,7 +272,7 @@ class PostsServiceImplTest {
 
         given(this.postsRepository.getByCodeAndEnabledTrue(Mockito.anyString())).willReturn(Mono.just(Mockito.mock(Posts.class)));
 
-        StepVerifier.create(postsService.incrementLikes("21213G0J2")).expectNextCount(1).verifyComplete();
+        StepVerifier.create(postsService.like("21213G0J2")).expectNextCount(1).verifyComplete();
     }
 
     @Test

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/controller/AuthorityController.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/controller/AuthorityController.java
@@ -42,18 +42,13 @@ public class AuthorityController {
      *
      * @param page 页码
      * @param size 大小
-     * @param type 类型
      * @return 查询的数据集，异常时返回204状态码
      */
     @GetMapping
-    public ResponseEntity<Flux<AuthorityVO>> retrieve(Integer page, Integer size, Character type) {
+    public ResponseEntity<Flux<AuthorityVO>> retrieve(@RequestParam int page, @RequestParam int size) {
         Flux<AuthorityVO> voFlux;
         try {
-            if (page != null && size != null) {
-                voFlux = authorityService.retrieve(page, size);
-            } else {
-                voFlux = authorityService.retrieve(type);
-            }
+            voFlux = authorityService.retrieve(page, size);
         } catch (Exception e) {
             logger.error("Retrieve authority occurred an error: ", e);
             return ResponseEntity.noContent().build();
@@ -64,14 +59,13 @@ public class AuthorityController {
     /**
      * 查询树形数据
      *
-     * @param type 类型
      * @return 查询到的数据，否则返回空
      */
     @GetMapping("/tree")
-    public ResponseEntity<Flux<TreeNode>> tree(Character type) {
+    public ResponseEntity<Flux<TreeNode>> tree() {
         Flux<TreeNode> authorities;
         try {
-            authorities = authorityService.tree(type);
+            authorities = authorityService.tree();
         } catch (Exception e) {
             logger.info("Retrieve authority occurred an error: ", e);
             return ResponseEntity.noContent().build();
@@ -112,6 +106,24 @@ public class AuthorityController {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(count);
+    }
+
+    /**
+     * 是否已存在
+     *
+     * @param name 用户名
+     * @return true-是，false-否
+     */
+    @GetMapping("/exist")
+    public ResponseEntity<Mono<Boolean>> exists(@RequestParam String name) {
+        Mono<Boolean> existsMono;
+        try {
+            existsMono = authorityService.exists(name);
+        } catch (Exception e) {
+            logger.error("Check authority is exist an error: ", e);
+            return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
+        }
+        return ResponseEntity.ok().body(existsMono);
     }
 
     /**

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/controller/GroupController.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/controller/GroupController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import top.leafage.common.basic.TreeNode;
-
 import javax.validation.Valid;
 
 /**
@@ -111,6 +110,24 @@ public class GroupController {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(count);
+    }
+
+    /**
+     * 是否已存在
+     *
+     * @param name 用户名
+     * @return true-是，false-否
+     */
+    @GetMapping("/exist")
+    public ResponseEntity<Mono<Boolean>> exists(@RequestParam String name) {
+        Mono<Boolean> existsMono;
+        try {
+            existsMono = groupService.exists(name);
+        } catch (Exception e) {
+            logger.error("Check group is exist an error: ", e);
+            return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
+        }
+        return ResponseEntity.ok().body(existsMono);
     }
 
     /**

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/controller/RoleController.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/controller/RoleController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import top.leafage.common.basic.TreeNode;
-
 import javax.validation.Valid;
 import java.util.Set;
 
@@ -118,6 +117,24 @@ public class RoleController {
             return ResponseEntity.noContent().build();
         }
         return ResponseEntity.ok(count);
+    }
+
+    /**
+     * 是否已存在
+     *
+     * @param name 用户名
+     * @return true-是，false-否
+     */
+    @GetMapping("/exist")
+    public ResponseEntity<Mono<Boolean>> exists(@RequestParam String name) {
+        Mono<Boolean> existsMono;
+        try {
+            existsMono = roleService.exists(name);
+        } catch (Exception e) {
+            logger.error("Check role is exist an error: ", e);
+            return ResponseEntity.status(HttpStatus.EXPECTATION_FAILED).build();
+        }
+        return ResponseEntity.ok().body(existsMono);
     }
 
     /**

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/dto/AccountDTO.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/dto/AccountDTO.java
@@ -3,9 +3,8 @@
  */
 package io.leafage.basic.hypervisor.dto;
 
-import javax.validation.constraints.NotNull;
+import javax.validation.constraints.NotBlank;
 import java.io.Serializable;
-import java.math.BigDecimal;
 
 /**
  * DTO class for Account
@@ -15,22 +14,23 @@ import java.math.BigDecimal;
 public class AccountDTO implements Serializable {
 
     private static final long serialVersionUID = 5424195124842285237L;
+
     /**
-     * 余额
+     * 代码（卡号）
      */
-    @NotNull
-    private BigDecimal balance;
+    @NotBlank
+    private String code;
     /**
      * 类型
      */
     private int type;
 
-    public BigDecimal getBalance() {
-        return balance;
+    public String getCode() {
+        return code;
     }
 
-    public void setBalance(BigDecimal balance) {
-        this.balance = balance;
+    public void setCode(String code) {
+        this.code = code;
     }
 
     public int getType() {

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/AuthorityRepository.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/AuthorityRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import java.util.Collection;
 
 /**
@@ -37,28 +36,12 @@ public interface AuthorityRepository extends ReactiveMongoRepository<Authority, 
     Flux<Authority> findByEnabledTrue();
 
     /**
-     * 根据类型查询权限
-     *
-     * @param type 类型
-     * @return 有效权限
-     */
-    Flux<Authority> findByTypeAndEnabledTrue(Character type);
-
-    /**
      * 根据code查询enabled信息
      *
      * @param code 代码
      * @return 权限信息
      */
     Mono<Authority> getByCodeAndEnabledTrue(String code);
-
-    /**
-     * 根据权限Id集合查询多条enabled信息
-     *
-     * @param ids id集合
-     * @return 权限信息
-     */
-    Flux<Authority> findByIdInAndEnabledTrue(Collection<ObjectId> ids);
 
     /**
      * 根据权限
@@ -68,4 +51,11 @@ public interface AuthorityRepository extends ReactiveMongoRepository<Authority, 
      */
     Flux<Authority> findByCodeInAndEnabledTrue(Collection<String> codes);
 
+    /**
+     * 是否已存在
+     *
+     * @param name 名称
+     * @return true-是，false-否
+     */
+    Mono<Boolean> existsByName(String name);
 }

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/GroupRepository.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/GroupRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import java.util.Collection;
@@ -54,4 +53,11 @@ public interface GroupRepository extends ReactiveMongoRepository<Group, ObjectId
      */
     Mono<Group> getByCodeAndEnabledTrue(@NotBlank String code);
 
+    /**
+     * 是否已存在
+     *
+     * @param name 名称
+     * @return true-是，false-否
+     */
+    Mono<Boolean> existsByName(String name);
 }

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/RoleAuthorityRepository.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/RoleAuthorityRepository.java
@@ -9,10 +9,7 @@ import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import java.util.Collection;
 
 /**
  * 角色权限repository
@@ -21,14 +18,6 @@ import java.util.Collection;
  **/
 @Repository
 public interface RoleAuthorityRepository extends ReactiveCrudRepository<RoleAuthority, ObjectId> {
-
-    /**
-     * 查询所有资源——根据角色ID集合
-     *
-     * @param roleIdList 角色ID集合
-     * @return Flux
-     */
-    Flux<RoleAuthority> findByRoleIdInAndEnabledTrue(@NotEmpty Collection<ObjectId> roleIdList);
 
     /**
      * 统计关联角色
@@ -44,7 +33,7 @@ public interface RoleAuthorityRepository extends ReactiveCrudRepository<RoleAuth
      * @param authorityId 权限主键
      * @return 关联数据集
      */
-    Flux<RoleAuthority> findByRoleId(@NotNull ObjectId authorityId);
+    Flux<RoleAuthority> findByRoleIdAndEnabledTrue(@NotNull ObjectId authorityId);
 
     /**
      * 根据角色查权限
@@ -52,5 +41,5 @@ public interface RoleAuthorityRepository extends ReactiveCrudRepository<RoleAuth
      * @param roleId 角色主键
      * @return 关联数据集
      */
-    Flux<RoleAuthority> findByAuthorityId(@NotNull ObjectId roleId);
+    Flux<RoleAuthority> findByAuthorityIdAndEnabledTrue(@NotNull ObjectId roleId);
 }

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/RoleRepository.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/RoleRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import java.util.Collection;
@@ -53,4 +52,12 @@ public interface RoleRepository extends ReactiveMongoRepository<Role, ObjectId> 
      * @return 角色信息
      */
     Flux<Role> findByCodeInAndEnabledTrue(@NotEmpty Collection<String> codes);
+
+    /**
+     * 是否已存在
+     *
+     * @param name 名称
+     * @return true-是，false-否
+     */
+    Mono<Boolean> existsByName(String name);
 }

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/UserGroupRepository.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/UserGroupRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import javax.validation.constraints.NotNull;
 
 /**
@@ -34,7 +33,7 @@ public interface UserGroupRepository extends ReactiveCrudRepository<UserGroup, O
      * @param groupId 分组主键
      * @return 关联数据集
      */
-    Flux<UserGroup> findByGroupId(@NotNull ObjectId groupId);
+    Flux<UserGroup> findByGroupIdAndEnabledTrue(@NotNull ObjectId groupId);
 
     /**
      * 根据用户查分组
@@ -42,5 +41,5 @@ public interface UserGroupRepository extends ReactiveCrudRepository<UserGroup, O
      * @param userId 用户主键
      * @return 关联数据集
      */
-    Flux<UserGroup> findByUserId(@NotNull ObjectId userId);
+    Flux<UserGroup> findByUserIdAndEnabledTrue(@NotNull ObjectId userId);
 }

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/UserRepository.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/UserRepository.java
@@ -11,8 +11,6 @@ import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import javax.validation.constraints.NotBlank;
-
 /**
  * 用户repository
  *
@@ -35,7 +33,7 @@ public interface UserRepository extends ReactiveMongoRepository<User, ObjectId> 
      * @param username 账号
      * @return 用户信息
      */
-    Mono<User> getByUsername(@NotBlank String username);
+    Mono<User> getByUsername(String username);
 
     /**
      * 根据username/mobile/email查询enabled信息
@@ -45,5 +43,15 @@ public interface UserRepository extends ReactiveMongoRepository<User, ObjectId> 
      * @param email    邮箱
      * @return 用户信息
      */
-    Mono<User> getByUsernameOrPhoneOrEmailAndEnabledTrue(@NotBlank String username, String phone, String email);
+    Mono<User> getByUsernameOrPhoneOrEmailAndEnabledTrue(String username, String phone, String email);
+
+    /**
+     * 是否已存在
+     *
+     * @param username 账号
+     * @param phone    电话
+     * @param email    邮箱
+     * @return true-是，false-否
+     */
+    Mono<Boolean> existsByUsernameOrPhoneOrEmail(String username, String phone, String email);
 }

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/UserRoleRepository.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/repository/UserRoleRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import javax.validation.constraints.NotNull;
 
 /**
@@ -42,13 +41,5 @@ public interface UserRoleRepository extends ReactiveCrudRepository<UserRole, Obj
      * @param roleId 角色主键
      * @return 关联数据集
      */
-    Flux<UserRole> findByRoleId(@NotNull ObjectId roleId);
-
-    /**
-     * 根据用户查角色
-     *
-     * @param userId 用户主键
-     * @return 关联数据集
-     */
-    Flux<UserRole> findByUserId(@NotNull ObjectId userId);
+    Flux<UserRole> findByRoleIdAndEnabledTrue(@NotNull ObjectId roleId);
 }

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/AuthorityService.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/AuthorityService.java
@@ -29,6 +29,7 @@ public interface AuthorityService extends ReactiveBasicService<AuthorityDTO, Aut
     /**
      * 查询构造树结构的数据
      *
+     * @param type 类型
      * @return 数据集
      */
     Flux<TreeNode> tree(Character type);

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/AuthorityService.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/AuthorityService.java
@@ -7,6 +7,7 @@ import io.leafage.basic.hypervisor.document.Authority;
 import io.leafage.basic.hypervisor.dto.AuthorityDTO;
 import io.leafage.basic.hypervisor.vo.AuthorityVO;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import top.leafage.common.basic.TreeNode;
 import top.leafage.common.reactive.ReactiveBasicService;
 import top.leafage.common.reactive.ReactiveTreeNodeAware;
@@ -19,18 +20,25 @@ import top.leafage.common.reactive.ReactiveTreeNodeAware;
 public interface AuthorityService extends ReactiveBasicService<AuthorityDTO, AuthorityVO>, ReactiveTreeNodeAware<Authority> {
 
     /**
-     * 查询指定类型的数据
-     *
-     * @param type 类型
-     * @return 数据集
-     */
-    Flux<AuthorityVO> retrieve(Character type);
-
-    /**
      * 查询构造树结构的数据
      *
-     * @param type 类型
      * @return 数据集
      */
-    Flux<TreeNode> tree(Character type);
+    Flux<TreeNode> tree();
+
+    /**
+     * 查询用户权限
+     *
+     * @param username 用户名
+     * @return 权限树
+     */
+    Flux<TreeNode> authorities(String username);
+
+    /**
+     * 是否已存在
+     *
+     * @param name 名称
+     * @return true-是，false-否
+     */
+    Mono<Boolean> exists(String name);
 }

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/GroupService.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/GroupService.java
@@ -7,6 +7,7 @@ import io.leafage.basic.hypervisor.document.Group;
 import io.leafage.basic.hypervisor.dto.GroupDTO;
 import io.leafage.basic.hypervisor.vo.GroupVO;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import top.leafage.common.basic.TreeNode;
 import top.leafage.common.reactive.ReactiveBasicService;
 import top.leafage.common.reactive.ReactiveTreeNodeAware;
@@ -24,4 +25,12 @@ public interface GroupService extends ReactiveBasicService<GroupDTO, GroupVO>, R
      * @return 数据集
      */
     Flux<TreeNode> tree();
+
+    /**
+     * 是否已存在
+     *
+     * @param name 名称
+     * @return true-是，false-否
+     */
+    Mono<Boolean> exists(String name);
 }

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/RoleService.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/RoleService.java
@@ -7,6 +7,7 @@ import io.leafage.basic.hypervisor.document.Role;
 import io.leafage.basic.hypervisor.dto.RoleDTO;
 import io.leafage.basic.hypervisor.vo.RoleVO;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import top.leafage.common.basic.TreeNode;
 import top.leafage.common.reactive.ReactiveBasicService;
 import top.leafage.common.reactive.ReactiveTreeNodeAware;
@@ -24,4 +25,12 @@ public interface RoleService extends ReactiveBasicService<RoleDTO, RoleVO>, Reac
      * @return 数据集
      */
     Flux<TreeNode> tree();
+
+    /**
+     * 是否已存在
+     *
+     * @param name 名称
+     * @return true-是，false-否
+     */
+    Mono<Boolean> exists(String name);
 }

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/UserService.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/UserService.java
@@ -17,11 +17,19 @@ import top.leafage.common.reactive.ReactiveBasicService;
 public interface UserService extends ReactiveBasicService<UserDTO, UserVO> {
 
     /**
+     * 是否已存在
+     *
+     * @param username 账号
+     * @return true-是，false-否
+     */
+    Mono<Boolean> exists(String username);
+
+    /**
      * 查用户details
      *
      * @param username 账户
      * @return 用户details
      */
-    Mono<UserDetails> fetchDetails(String username);
+    Mono<UserDetails> details(String username);
 
 }

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/AccountServiceImpl.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/AccountServiceImpl.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import reactor.core.publisher.Mono;
 import top.leafage.common.basic.AbstractBasicService;
-
 import java.util.NoSuchElementException;
 
 /**
@@ -40,7 +39,7 @@ public class AccountServiceImpl extends AbstractBasicService implements AccountS
 
     @Override
     public Mono<AccountVO> modify(String code, AccountDTO accountDTO) {
-        Assert.hasText(code, "code is blank");
+        Assert.hasText(code, "code is blank.");
         return accountRepository.getByCodeAndEnabledTrue(code).switchIfEmpty(Mono.error(NoSuchElementException::new))
                 .flatMap(accountVO -> {
                     Account info = new Account();
@@ -51,7 +50,7 @@ public class AccountServiceImpl extends AbstractBasicService implements AccountS
 
     @Override
     public Mono<Void> remove(String code) {
-        Assert.hasText(code, "code is blank");
+        Assert.hasText(code, "code is blank.");
         return accountRepository.getByCodeAndEnabledTrue(code).switchIfEmpty(Mono.error(NoSuchElementException::new))
                 .flatMap(account -> accountRepository.deleteById(account.getId()));
     }

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/AuthorityServiceImpl.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/AuthorityServiceImpl.java
@@ -4,9 +4,12 @@
 package io.leafage.basic.hypervisor.service.impl;
 
 import io.leafage.basic.hypervisor.document.Authority;
+import io.leafage.basic.hypervisor.document.User;
 import io.leafage.basic.hypervisor.dto.AuthorityDTO;
 import io.leafage.basic.hypervisor.repository.AuthorityRepository;
 import io.leafage.basic.hypervisor.repository.RoleAuthorityRepository;
+import io.leafage.basic.hypervisor.repository.UserRepository;
+import io.leafage.basic.hypervisor.repository.UserRoleRepository;
 import io.leafage.basic.hypervisor.service.AuthorityService;
 import io.leafage.basic.hypervisor.vo.AuthorityVO;
 import org.springframework.beans.BeanUtils;
@@ -28,17 +31,19 @@ import java.util.*;
 @Service
 public class AuthorityServiceImpl extends AbstractBasicService implements AuthorityService {
 
+    private static final String MESSAGE = "code is blank.";
+
+    private final UserRepository userRepository;
+    private final UserRoleRepository userRoleRepository;
     private final RoleAuthorityRepository roleAuthorityRepository;
     private final AuthorityRepository authorityRepository;
 
-    public AuthorityServiceImpl(RoleAuthorityRepository roleAuthorityRepository, AuthorityRepository authorityRepository) {
+    public AuthorityServiceImpl(UserRepository userRepository, UserRoleRepository userRoleRepository,
+                                RoleAuthorityRepository roleAuthorityRepository, AuthorityRepository authorityRepository) {
+        this.userRepository = userRepository;
+        this.userRoleRepository = userRoleRepository;
         this.roleAuthorityRepository = roleAuthorityRepository;
         this.authorityRepository = authorityRepository;
-    }
-
-    @Override
-    public Flux<AuthorityVO> retrieve(Character type) {
-        return authorityRepository.findByTypeAndEnabledTrue(type).flatMap(this::convertOuter);
     }
 
     @Override
@@ -48,31 +53,32 @@ public class AuthorityServiceImpl extends AbstractBasicService implements Author
     }
 
     @Override
-    public Flux<TreeNode> tree(Character type) {
-        Flux<Authority> authorities;
-        if (Objects.nonNull(type) && Character.isLetter(type)) {
-            authorities = authorityRepository.findByTypeAndEnabledTrue(type)
-                    .switchIfEmpty(Mono.error(NoSuchElementException::new));
-        } else {
-            authorities = authorityRepository.findByEnabledTrue().switchIfEmpty(Mono.error(NoSuchElementException::new));
-        }
-        return authorities.filter(a -> Objects.isNull(a.getSuperior())).flatMap(authority -> {
-            TreeNode treeNode = this.constructNode(authority.getCode(), authority);
+    public Flux<TreeNode> tree() {
+        Flux<Authority> authorities = authorityRepository.findByEnabledTrue()
+                .switchIfEmpty(Mono.error(NoSuchElementException::new));
+        return this.convertTree(authorities);
+    }
 
-            Set<String> expand = new HashSet<>();
-            expand.add("icon");
-            expand.add("path");
+    @Override
+    public Flux<TreeNode> authorities(String username) {
+        Assert.hasText(username, "username is blank.");
+        Mono<User> userMono = userRepository.getByUsernameOrPhoneOrEmailAndEnabledTrue(username, username, username)
+                .switchIfEmpty(Mono.error(NoSuchElementException::new));
 
-            return this.children(authority, authorities, expand).collectList().map(treeNodes -> {
-                treeNode.setChildren(treeNodes);
-                return treeNode;
-            });
-        });
+        return userMono.map(user -> userRoleRepository.findByUserIdAndEnabledTrue(user.getId()).flatMap(userRole ->
+                roleAuthorityRepository.findByRoleIdAndEnabledTrue(userRole.getRoleId()).flatMap(roleAuthority ->
+                        authorityRepository.findById(roleAuthority.getAuthorityId())))).flatMapMany(this::convertTree);
+    }
+
+    @Override
+    public Mono<Boolean> exists(String name) {
+        Assert.hasText(name, "name is blank.");
+        return authorityRepository.existsByName(name);
     }
 
     @Override
     public Mono<AuthorityVO> fetch(String code) {
-        Assert.hasText(code, "code is blank");
+        Assert.hasText(code, MESSAGE);
         return authorityRepository.getByCodeAndEnabledTrue(code).flatMap(this::fetchOuter)
                 .switchIfEmpty(Mono.error(NoSuchElementException::new));
     }
@@ -97,7 +103,7 @@ public class AuthorityServiceImpl extends AbstractBasicService implements Author
 
     @Override
     public Mono<AuthorityVO> modify(String code, AuthorityDTO authorityDTO) {
-        Assert.hasText(code, "code is blank");
+        Assert.hasText(code, MESSAGE);
         Mono<Authority> authorityMono = authorityRepository.getByCodeAndEnabledTrue(code)
                 .switchIfEmpty(Mono.error(NoSuchElementException::new));
         // 设置上级
@@ -177,6 +183,27 @@ public class AuthorityServiceImpl extends AbstractBasicService implements Author
             });
         }
         return voMono;
+    }
+
+    /**
+     * convert Authority to TreeNode
+     *
+     * @param authorities flux of authority
+     * @return TreeNode of Flux
+     */
+    private Flux<TreeNode> convertTree(Flux<Authority> authorities) {
+        return authorities.filter(a -> Objects.isNull(a.getSuperior())).flatMap(authority -> {
+            TreeNode treeNode = this.constructNode(authority.getCode(), authority);
+
+            Set<String> expand = new HashSet<>();
+            expand.add("icon");
+            expand.add("path");
+
+            return this.children(authority, authorities, expand).collectList().map(treeNodes -> {
+                treeNode.setChildren(treeNodes);
+                return treeNode;
+            });
+        });
     }
 
     /**

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/AuthorityServiceImpl.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/AuthorityServiceImpl.java
@@ -18,7 +18,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import top.leafage.common.basic.AbstractBasicService;
 import top.leafage.common.basic.TreeNode;
-
 import java.util.*;
 
 /**
@@ -51,7 +50,7 @@ public class AuthorityServiceImpl extends AbstractBasicService implements Author
     @Override
     public Flux<TreeNode> tree(Character type) {
         Flux<Authority> authorities;
-        if (Character.isLetter(type)) {
+        if (Objects.nonNull(type) && Character.isLetter(type)) {
             authorities = authorityRepository.findByTypeAndEnabledTrue(type)
                     .switchIfEmpty(Mono.error(NoSuchElementException::new));
         } else {

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/GroupServiceImpl.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/GroupServiceImpl.java
@@ -20,7 +20,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import top.leafage.common.basic.AbstractBasicService;
 import top.leafage.common.basic.TreeNode;
-
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
@@ -68,6 +67,11 @@ public class GroupServiceImpl extends AbstractBasicService implements GroupServi
                 return treeNode;
             });
         });
+    }
+
+    @Override
+    public Mono<Boolean> exists(String name) {
+        return groupRepository.existsByName(name);
     }
 
     @Override

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/RoleAuthorityServiceImpl.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/RoleAuthorityServiceImpl.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -33,7 +32,7 @@ public class RoleAuthorityServiceImpl implements RoleAuthorityService {
     @Override
     public Flux<AuthorityVO> authorities(String code) {
         return roleRepository.getByCodeAndEnabledTrue(code).switchIfEmpty(Mono.error(NoSuchElementException::new))
-                .flatMapMany(group -> roleAuthorityRepository.findByRoleId(group.getId()).flatMap(roleAuthority ->
+                .flatMapMany(group -> roleAuthorityRepository.findByRoleIdAndEnabledTrue(group.getId()).flatMap(roleAuthority ->
                         authorityRepository.findById(roleAuthority.getAuthorityId()).map(user -> {
                             AuthorityVO authorityVO = new AuthorityVO();
                             BeanUtils.copyProperties(user, authorityVO);
@@ -45,7 +44,7 @@ public class RoleAuthorityServiceImpl implements RoleAuthorityService {
     @Override
     public Flux<RoleVO> roles(String code) {
         return authorityRepository.getByCodeAndEnabledTrue(code).switchIfEmpty(Mono.error(NoSuchElementException::new))
-                .flatMapMany(authority -> roleAuthorityRepository.findByAuthorityId(authority.getId()).flatMap(userRole ->
+                .flatMapMany(authority -> roleAuthorityRepository.findByAuthorityIdAndEnabledTrue(authority.getId()).flatMap(userRole ->
                         roleRepository.findById(userRole.getRoleId()).map(role -> {
                             RoleVO roleVO = new RoleVO();
                             BeanUtils.copyProperties(role, roleVO);

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/RoleServiceImpl.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/RoleServiceImpl.java
@@ -18,7 +18,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import top.leafage.common.basic.AbstractBasicService;
 import top.leafage.common.basic.TreeNode;
-
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
@@ -29,6 +28,8 @@ import java.util.Objects;
  **/
 @Service
 public class RoleServiceImpl extends AbstractBasicService implements RoleService {
+
+    private static final String MESSAGE = "code is blank.";
 
     private final UserRoleRepository userRoleRepository;
     private final RoleRepository roleRepository;
@@ -62,8 +63,14 @@ public class RoleServiceImpl extends AbstractBasicService implements RoleService
     }
 
     @Override
+    public Mono<Boolean> exists(String name) {
+        Assert.hasText(name, "name is blank.");
+        return roleRepository.existsByName(name);
+    }
+
+    @Override
     public Mono<RoleVO> fetch(String code) {
-        Assert.hasText(code, "code is blank");
+        Assert.hasText(code, MESSAGE);
         return roleRepository.getByCodeAndEnabledTrue(code).flatMap(this::fetchOuter)
                 .switchIfEmpty(Mono.error(NoSuchElementException::new));
     }
@@ -88,7 +95,7 @@ public class RoleServiceImpl extends AbstractBasicService implements RoleService
 
     @Override
     public Mono<RoleVO> modify(String code, RoleDTO roleDTO) {
-        Assert.hasText(code, "code is blank");
+        Assert.hasText(code, MESSAGE);
         Mono<Role> roleMono = roleRepository.getByCodeAndEnabledTrue(code)
                 .switchIfEmpty(Mono.error(NoSuchElementException::new));
         // 设置上级

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/UserGroupServiceImpl.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/UserGroupServiceImpl.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -33,7 +32,7 @@ public class UserGroupServiceImpl implements UserGroupService {
     @Override
     public Flux<UserVO> users(String code) {
         return groupRepository.getByCodeAndEnabledTrue(code).switchIfEmpty(Mono.error(NoSuchElementException::new))
-                .flatMapMany(group -> userGroupRepository.findByGroupId(group.getId()).flatMap(userGroup ->
+                .flatMapMany(group -> userGroupRepository.findByGroupIdAndEnabledTrue(group.getId()).flatMap(userGroup ->
                         userRepository.findById(userGroup.getUserId()).map(user -> {
                             UserVO userVO = new UserVO();
                             BeanUtils.copyProperties(user, userVO);
@@ -45,7 +44,7 @@ public class UserGroupServiceImpl implements UserGroupService {
     @Override
     public Flux<GroupVO> groups(String username) {
         return userRepository.getByUsername(username).switchIfEmpty(Mono.error(NoSuchElementException::new))
-                .flatMapMany(user -> userGroupRepository.findByUserId(user.getId()).flatMap(userGroup ->
+                .flatMapMany(user -> userGroupRepository.findByUserIdAndEnabledTrue(user.getId()).flatMap(userGroup ->
                         groupRepository.findById(userGroup.getGroupId()).map(group -> {
                             GroupVO groupVO = new GroupVO();
                             BeanUtils.copyProperties(group, groupVO);

--- a/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/UserRoleServiceImpl.java
+++ b/hypervisor/src/main/java/io/leafage/basic/hypervisor/service/impl/UserRoleServiceImpl.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
 import javax.naming.NotContextException;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -35,7 +34,7 @@ public class UserRoleServiceImpl implements UserRoleService {
     public Flux<UserVO> users(String code) {
         Assert.hasText(code, "code is blank");
         return roleRepository.getByCodeAndEnabledTrue(code).switchIfEmpty(Mono.error(NoSuchElementException::new))
-                .flatMapMany(role -> userRoleRepository.findByRoleId(role.getId()).flatMap(userRole ->
+                .flatMapMany(role -> userRoleRepository.findByRoleIdAndEnabledTrue(role.getId()).flatMap(userRole ->
                         userRepository.findById(userRole.getUserId()).map(user -> {
                             UserVO userVO = new UserVO();
                             BeanUtils.copyProperties(user, userVO);
@@ -48,7 +47,7 @@ public class UserRoleServiceImpl implements UserRoleService {
     public Flux<RoleVO> roles(String username) {
         Assert.hasText(username, "username is blank");
         return userRepository.getByUsername(username).switchIfEmpty(Mono.error(NoSuchElementException::new))
-                .flatMapMany(user -> userRoleRepository.findByUserId(user.getId()).flatMap(userRole ->
+                .flatMapMany(user -> userRoleRepository.findByUserIdAndEnabledTrue(user.getId()).flatMap(userRole ->
                         roleRepository.findById(userRole.getRoleId()).map(role -> {
                             RoleVO roleVO = new RoleVO();
                             BeanUtils.copyProperties(role, roleVO);

--- a/hypervisor/src/test/java/io/leafage/basic/hypervisor/controller/AccountControllerTest.java
+++ b/hypervisor/src/test/java/io/leafage/basic/hypervisor/controller/AccountControllerTest.java
@@ -12,9 +12,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
-
 import java.math.BigDecimal;
-
 import static org.mockito.BDDMockito.given;
 
 /**
@@ -49,7 +47,7 @@ class AccountControllerTest {
         given(this.accountService.create(Mockito.any(AccountDTO.class))).willReturn(Mono.just(accountVO));
 
         AccountDTO accountDTO = new AccountDTO();
-        accountDTO.setBalance(new BigDecimal("1000.09"));
+        accountDTO.setCode("6431659823235265");
         webTestClient.post().uri("/account").bodyValue(accountDTO).exchange()
                 .expectStatus().isCreated()
                 .expectBody().jsonPath("$.balance").isEqualTo("1000.09");
@@ -62,7 +60,7 @@ class AccountControllerTest {
         given(this.accountService.modify(Mockito.anyString(), Mockito.any(AccountDTO.class))).willReturn(Mono.just(accountVO));
 
         AccountDTO accountDTO = new AccountDTO();
-        accountDTO.setBalance(new BigDecimal("1000.09"));
+        accountDTO.setCode("6431659823235265");
         webTestClient.put().uri("/account/{code}", "21612OL34").bodyValue(accountDTO).exchange()
                 .expectStatus().isAccepted()
                 .expectBody().jsonPath("$.balance").isEqualTo("1000.09");

--- a/hypervisor/src/test/java/io/leafage/basic/hypervisor/controller/AuthorityControllerTest.java
+++ b/hypervisor/src/test/java/io/leafage/basic/hypervisor/controller/AuthorityControllerTest.java
@@ -43,14 +43,14 @@ class AuthorityControllerTest {
         given(this.authorityService.retrieve(0, 2)).willReturn(Flux.just(authorityVO));
 
         webTestClient.get().uri(uriBuilder -> uriBuilder.path("/authority").queryParam("page", 0)
-                .queryParam("size", 2).build()).exchange()
+                        .queryParam("size", 2).build()).exchange()
                 .expectStatus().isOk().expectBodyList(RoleVO.class);
     }
 
     @Test
     void tree() {
         TreeNode treeNode = new TreeNode("21612OL34", "test");
-        given(this.authorityService.tree('M')).willReturn(Flux.just(treeNode));
+        given(this.authorityService.tree()).willReturn(Flux.just(treeNode));
 
         webTestClient.get().uri("/authority/tree").exchange()
                 .expectStatus().isOk().expectBodyList(TreeNode.class);
@@ -71,6 +71,14 @@ class AuthorityControllerTest {
         given(this.authorityService.count()).willReturn(Mono.just(2L));
 
         webTestClient.get().uri("/authority/count").exchange().expectStatus().isOk();
+    }
+
+    @Test
+    void exists() {
+        given(this.authorityService.exists(Mockito.anyString())).willReturn(Mono.just(Boolean.TRUE));
+
+        webTestClient.get().uri(uriBuilder -> uriBuilder.path("/authority/exist")
+                .queryParam("name", "test").build()).exchange().expectStatus().isOk();
     }
 
     @Test

--- a/hypervisor/src/test/java/io/leafage/basic/hypervisor/controller/GroupControllerTest.java
+++ b/hypervisor/src/test/java/io/leafage/basic/hypervisor/controller/GroupControllerTest.java
@@ -76,6 +76,14 @@ class GroupControllerTest {
     }
 
     @Test
+    void exists() {
+        given(this.groupService.exists(Mockito.anyString())).willReturn(Mono.just(Boolean.TRUE));
+
+        webTestClient.get().uri(uriBuilder -> uriBuilder.path("/group/exist")
+                .queryParam("name", "test").build()).exchange().expectStatus().isOk();
+    }
+
+    @Test
     void create() {
         GroupVO groupVO = new GroupVO();
         groupVO.setName("test");

--- a/hypervisor/src/test/java/io/leafage/basic/hypervisor/controller/RoleControllerTest.java
+++ b/hypervisor/src/test/java/io/leafage/basic/hypervisor/controller/RoleControllerTest.java
@@ -83,6 +83,14 @@ class RoleControllerTest {
     }
 
     @Test
+    void exists() {
+        given(this.roleService.exists(Mockito.anyString())).willReturn(Mono.just(Boolean.TRUE));
+
+        webTestClient.get().uri(uriBuilder -> uriBuilder.path("/role/exist")
+                .queryParam("name", "test").build()).exchange().expectStatus().isOk();
+    }
+
+    @Test
     void create() {
         RoleVO roleVO = new RoleVO();
         roleVO.setName("test");

--- a/hypervisor/src/test/java/io/leafage/basic/hypervisor/controller/UserControllerTest.java
+++ b/hypervisor/src/test/java/io/leafage/basic/hypervisor/controller/UserControllerTest.java
@@ -4,6 +4,7 @@ import io.leafage.basic.hypervisor.document.UserGroup;
 import io.leafage.basic.hypervisor.document.UserRole;
 import io.leafage.basic.hypervisor.domain.UserDetails;
 import io.leafage.basic.hypervisor.dto.UserDTO;
+import io.leafage.basic.hypervisor.service.AuthorityService;
 import io.leafage.basic.hypervisor.service.UserGroupService;
 import io.leafage.basic.hypervisor.service.UserRoleService;
 import io.leafage.basic.hypervisor.service.UserService;
@@ -21,9 +22,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
+import top.leafage.common.basic.TreeNode;
 import java.util.Collections;
-
 import static org.mockito.BDDMockito.given;
 
 /**
@@ -44,6 +44,9 @@ class UserControllerTest {
     @MockBean
     private UserRoleService userRoleService;
 
+    @MockBean
+    private AuthorityService authorityService;
+
     @Autowired
     private WebTestClient webTestClient;
 
@@ -54,7 +57,7 @@ class UserControllerTest {
         given(this.userService.retrieve(0, 2)).willReturn(Flux.just(userVO));
 
         webTestClient.get().uri(uriBuilder -> uriBuilder.path("/user").queryParam("page", 0)
-                .queryParam("size", 2).build()).exchange()
+                        .queryParam("size", 2).build()).exchange()
                 .expectStatus().isOk().expectBodyList(UserVO.class);
     }
 
@@ -75,7 +78,7 @@ class UserControllerTest {
     void fetchDetails() {
         UserDetails userDetails = new UserDetails();
         userDetails.setUsername("little3201");
-        given(this.userService.fetchDetails(Mockito.anyString())).willReturn(Mono.just(userDetails));
+        given(this.userService.details(Mockito.anyString())).willReturn(Mono.just(userDetails));
 
         webTestClient.get().uri("/user/{username}/details", "little3201").exchange()
                 .expectStatus().isOk()
@@ -87,6 +90,13 @@ class UserControllerTest {
         given(this.userService.count()).willReturn(Mono.just(2L));
 
         webTestClient.get().uri("/user/count").exchange().expectStatus().isOk();
+    }
+
+    @Test
+    void exists() {
+        given(this.userService.exists(Mockito.anyString())).willReturn(Mono.just(Boolean.TRUE));
+
+        webTestClient.get().uri("/user/{username}/exist", "little3201").exchange().expectStatus().isOk();
     }
 
     @Test
@@ -168,5 +178,15 @@ class UserControllerTest {
                 .bodyValue(Collections.singleton("21612OL34"))
                 .exchange().expectStatus().isAccepted()
                 .expectBodyList(UserRole.class);
+    }
+
+    @Test
+    void authority() {
+        TreeNode treeNode = new TreeNode("21612OL31", "Dashboard");
+        given(this.authorityService.authorities(Mockito.anyString())).willReturn(Flux.just(treeNode));
+
+        webTestClient.get().uri("/user/{username}/authority", "little3201").exchange()
+                .expectStatus().isOk()
+                .expectBodyList(RoleVO.class);
     }
 }

--- a/hypervisor/src/test/java/io/leafage/basic/hypervisor/service/impl/GroupServiceImplTest.java
+++ b/hypervisor/src/test/java/io/leafage/basic/hypervisor/service/impl/GroupServiceImplTest.java
@@ -20,7 +20,6 @@ import org.springframework.data.domain.PageRequest;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
 import static org.mockito.BDDMockito.given;
 
 /**
@@ -75,8 +74,6 @@ class GroupServiceImplTest {
 
         given(this.userRepository.findById(Mockito.any(ObjectId.class))).willReturn(Mono.just(Mockito.mock(User.class)));
 
-        User user = new User();
-        user.setNickname("test");
         StepVerifier.create(groupService.retrieve(0, 2)).expectNextCount(1).verifyComplete();
     }
 
@@ -169,5 +166,13 @@ class GroupServiceImplTest {
     void count() {
         given(this.groupRepository.count()).willReturn(Mono.just(2L));
         StepVerifier.create(groupService.count()).expectNextCount(1).verifyComplete();
+    }
+
+
+    @Test
+    void exists() {
+        given(this.groupRepository.existsByName(Mockito.anyString())).willReturn(Mono.just(Boolean.TRUE));
+
+        StepVerifier.create(groupService.exists("vip")).expectNext(Boolean.TRUE).verifyComplete();
     }
 }

--- a/hypervisor/src/test/java/io/leafage/basic/hypervisor/service/impl/RoleAuthorityServiceImplTest.java
+++ b/hypervisor/src/test/java/io/leafage/basic/hypervisor/service/impl/RoleAuthorityServiceImplTest.java
@@ -16,9 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
 import java.util.Collections;
-
 import static org.mockito.BDDMockito.given;
 
 /**
@@ -51,7 +49,7 @@ class RoleAuthorityServiceImplTest {
         RoleAuthority roleAuthority = new RoleAuthority();
         roleAuthority.setAuthorityId(id);
         roleAuthority.setRoleId(new ObjectId());
-        given(this.roleAuthorityRepository.findByRoleId(Mockito.any(ObjectId.class))).willReturn(Flux.just(roleAuthority));
+        given(this.roleAuthorityRepository.findByRoleIdAndEnabledTrue(Mockito.any(ObjectId.class))).willReturn(Flux.just(roleAuthority));
 
         given(this.authorityRepository.findById(Mockito.any(ObjectId.class))).willReturn(Mono.just(Mockito.mock(Authority.class)));
 
@@ -68,7 +66,7 @@ class RoleAuthorityServiceImplTest {
         RoleAuthority roleAuthority = new RoleAuthority();
         roleAuthority.setAuthorityId(id);
         roleAuthority.setRoleId(new ObjectId());
-        given(this.roleAuthorityRepository.findByAuthorityId(Mockito.any(ObjectId.class))).willReturn(Flux.just(roleAuthority));
+        given(this.roleAuthorityRepository.findByAuthorityIdAndEnabledTrue(Mockito.any(ObjectId.class))).willReturn(Flux.just(roleAuthority));
 
         given(this.roleRepository.findById(Mockito.any(ObjectId.class))).willReturn(Mono.just(Mockito.mock(Role.class)));
 

--- a/hypervisor/src/test/java/io/leafage/basic/hypervisor/service/impl/RoleServiceImplTest.java
+++ b/hypervisor/src/test/java/io/leafage/basic/hypervisor/service/impl/RoleServiceImplTest.java
@@ -18,7 +18,6 @@ import org.springframework.data.domain.PageRequest;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
 import static org.mockito.BDDMockito.given;
 
 /**
@@ -136,5 +135,13 @@ class RoleServiceImplTest {
     void count() {
         given(this.roleRepository.count()).willReturn(Mono.just(2L));
         StepVerifier.create(roleService.count()).expectNextCount(1).verifyComplete();
+    }
+
+
+    @Test
+    void exists() {
+        given(this.roleRepository.existsByName(Mockito.anyString())).willReturn(Mono.just(Boolean.TRUE));
+
+        StepVerifier.create(roleService.exists("vip")).expectNext(Boolean.TRUE).verifyComplete();
     }
 }

--- a/hypervisor/src/test/java/io/leafage/basic/hypervisor/service/impl/UserGroupServiceImplTest.java
+++ b/hypervisor/src/test/java/io/leafage/basic/hypervisor/service/impl/UserGroupServiceImplTest.java
@@ -16,9 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
 import java.util.Collections;
-
 import static org.mockito.BDDMockito.given;
 
 /**
@@ -51,7 +49,7 @@ class UserGroupServiceImplTest {
         UserGroup userGroup = new UserGroup();
         userGroup.setGroupId(id);
         userGroup.setUserId(new ObjectId());
-        given(this.userGroupRepository.findByGroupId(Mockito.any(ObjectId.class))).willReturn(Flux.just(userGroup));
+        given(this.userGroupRepository.findByGroupIdAndEnabledTrue(Mockito.any(ObjectId.class))).willReturn(Flux.just(userGroup));
 
         given(this.userRepository.findById(Mockito.any(ObjectId.class))).willReturn(Mono.just(Mockito.mock(User.class)));
         StepVerifier.create(userGroupService.users("21612OL34")).expectNextCount(1).verifyComplete();
@@ -67,7 +65,7 @@ class UserGroupServiceImplTest {
         UserGroup userGroup = new UserGroup();
         userGroup.setGroupId(new ObjectId());
         userGroup.setUserId(id);
-        given(this.userGroupRepository.findByUserId(Mockito.any(ObjectId.class))).willReturn(Flux.just(userGroup));
+        given(this.userGroupRepository.findByUserIdAndEnabledTrue(Mockito.any(ObjectId.class))).willReturn(Flux.just(userGroup));
 
         given(this.groupRepository.findById(Mockito.any(ObjectId.class))).willReturn(Mono.just(Mockito.mock(Group.class)));
         StepVerifier.create(userGroupService.groups("21612OL34")).expectNextCount(1).verifyComplete();

--- a/hypervisor/src/test/java/io/leafage/basic/hypervisor/service/impl/UserRoleServiceImplTest.java
+++ b/hypervisor/src/test/java/io/leafage/basic/hypervisor/service/impl/UserRoleServiceImplTest.java
@@ -16,9 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-
 import java.util.Collections;
-
 import static org.mockito.BDDMockito.given;
 
 /**
@@ -51,7 +49,7 @@ class UserRoleServiceImplTest {
         UserRole userRole = new UserRole();
         userRole.setRoleId(id);
         userRole.setUserId(new ObjectId());
-        given(this.userRoleRepository.findByRoleId(Mockito.any(ObjectId.class))).willReturn(Flux.just(userRole));
+        given(this.userRoleRepository.findByRoleIdAndEnabledTrue(Mockito.any(ObjectId.class))).willReturn(Flux.just(userRole));
 
         given(this.userRepository.findById(Mockito.any(ObjectId.class))).willReturn(Mono.just(Mockito.mock(User.class)));
         StepVerifier.create(userRoleService.users("21612OL34")).expectNextCount(1).verifyComplete();
@@ -67,7 +65,7 @@ class UserRoleServiceImplTest {
         UserRole userRole = new UserRole();
         userRole.setUserId(id);
         userRole.setRoleId(new ObjectId());
-        given(this.userRoleRepository.findByUserId(Mockito.any(ObjectId.class))).willReturn(Flux.just(userRole));
+        given(this.userRoleRepository.findByUserIdAndEnabledTrue(Mockito.any(ObjectId.class))).willReturn(Flux.just(userRole));
 
         given(this.roleRepository.findById(Mockito.any(ObjectId.class))).willReturn(Mono.just(Mockito.mock(Role.class)));
 


### PR DESCRIPTION
更新authority的tree接口逻辑，只查询所有，不接收参数; 
添加唯一校验接口，测试；
添加用户权限查询接口；
更新userService中查询登录用户权限的逻辑实现，删除不再使用的接口；